### PR TITLE
Added precompiled headers for BeastEngine

### DIFF
--- a/include/BeastEngine/Definitions/Types.h
+++ b/include/BeastEngine/Definitions/Types.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <memory>
 #include <spdlog/logger.h>
 
 namespace be

--- a/include/BeastEngine/beastengine.h
+++ b/include/BeastEngine/beastengine.h
@@ -4,8 +4,6 @@
 #include "BeastEngine/Loggers/LoggersFactory.h"
 #include "BeastEngine/Loggers/LoggersTypes.h"
 
-#include <string>
-
 namespace be
 {
     struct EngineConfig

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,3 +27,11 @@ configure_file(
 	"${BEAST_INCLUDE_DIR}/BeastEngine/Definitions/Versions.h.in"
 	"${BEAST_INCLUDE_DIR}/BeastEngine/Definitions/Versions.h"
 )
+
+target_precompile_headers(
+	${BEAST_LIB_TARGET_NAME}
+	PRIVATE
+		<string>
+		<vector>
+		<memory>
+)


### PR DESCRIPTION
Added instructions to `CMake` which provides the `BeastEngine` project with precompiled headers.
The headers now include:

 - `<vector>`
 - `<string>`
 - `<memory>`

This list will be extended as needed.