### PR TITLE
8 engine development scripts refresh

### DIFF
--- a/scripts/src/beastengine/beast_command_helper.py
+++ b/scripts/src/beastengine/beast_command_helper.py
@@ -6,6 +6,7 @@ class BeastCommandHelper:
 
     COMMAND_NAME_INIT = 'init'
     COMMAND_NAME_CONFIGURE = 'configure'
+    COMMAND_NAME_INSTALL_DEPENDENCIES = 'install'
     COMMAND_NAME_BUILD = 'build'
     COMMAND_NAME_CLASS = 'class'
     COMMAND_NAME_CLASS_ADD = 'add'
@@ -23,6 +24,7 @@ class BeastCommandHelper:
             'reset': colorama.Fore.RESET,
             'init': BeastCommandHelper.COMMAND_NAME_INIT,
             'configure': BeastCommandHelper.COMMAND_NAME_CONFIGURE,
+            'install_deps': BeastCommandHelper.COMMAND_NAME_INSTALL_DEPENDENCIES,
             'build': BeastCommandHelper.COMMAND_NAME_BUILD,
             'class': BeastCommandHelper.COMMAND_NAME_CLASS,
             'class_add': BeastCommandHelper.COMMAND_NAME_CLASS_ADD,

--- a/scripts/src/beastengine/beastengine.py
+++ b/scripts/src/beastengine/beastengine.py
@@ -25,6 +25,7 @@ You can also use it for building the project with desired configuration.{reset}
 {purple}Configuration commands{white}
  {green}{init}{white}          Installs BeastEngine. Creates 'build' directory and downloads all necessary dependencies
  {green}{configure}{white}     Configures CMake project inside the 'build' directory
+ {green}{install_deps}{white}       Installs and/or updates project dependencies 
 
 {purple}Development commands{white}
  {green}{build}{white}         Builds BeastEngine project based on given parameters
@@ -77,3 +78,5 @@ You can also use it for building the project with desired configuration.{reset}
             Build(self.config_manager, self.cmake).execute()
         elif command_line_args.command == BeastCommandHelper.COMMAND_NAME_CLASS:
             ClassCommand(self.config_manager, self.cmake, self.target_config_manager, self.class_files_helper)
+        elif command_line_args.command == BeastCommandHelper.COMMAND_NAME_INSTALL_DEPENDENCIES:
+            self.conan.install(True)

--- a/scripts/src/beastengine/commands/class_commands/class_add.py
+++ b/scripts/src/beastengine/commands/class_commands/class_add.py
@@ -9,7 +9,7 @@ from src.config.config_manager import Config, ConfigManager
 class ClassAdd:
     PROGRAM_USAGE = '''{green}beast {class} {class_add} <class_name> [<args>]
 
-{white}This command creates single header and single source files under the headers and sources base directories.
+{white}This command creates single header and single source files under the headers and sources base directories of the given CMake target.
 If class name contains slashes, it will create subdirectories inside base directory.
 Eg. {yellow}beast {class} {class_add} subDir/myClass{white} will result in creation of the 'myClass.h' and 'myClass.cpp'
 files under the 'baseDirectory/subDir' path.{white}
@@ -33,7 +33,7 @@ files under the 'baseDirectory/subDir' path.{white}
         group.add_argument('-ho', '--header_only', help='create only header file and omit the source file', action='store_true')
         group.add_argument('-so', '--source_only', help='create only source file and omit the header file', action='store_true')
 
-        command_line_arguments = parser.parse_args(sys.argv[3:])
+        command_line_arguments = parser.parse_args(sys.argv[4:])
         is_verbose = is_verbose_set(command_line_arguments)
 
         class_name = command_line_arguments.class_name

--- a/scripts/src/beastengine/commands/class_commands/class_files_helper.py
+++ b/scripts/src/beastengine/commands/class_commands/class_files_helper.py
@@ -32,7 +32,7 @@ class ClassFilesHelper:
 
     def create_class_header(self, class_name, headers_base_dir, is_verbose, namespace=None):
         cwd = get_project_path()
-
+        print(is_verbose)
         if class_name.find(self.CLASS_NAME_DIRECTORY_SEPARATOR) != -1:
             class_sub_directories_path = self.__get_class_subdirectories_path(class_name)
             headers_path = Path(f'{headers_base_dir}/{class_sub_directories_path}')
@@ -56,7 +56,7 @@ class ClassFilesHelper:
         source_file_name = self.get_source_file_name(class_name)
         source_file_path = f'{sources_base_dir}/{source_file_name}'
 
-        self.__create_source_file(source_file_path, "", cwd, is_verbose, namespace)
+        self.__create_source_file(source_file_path, cwd, is_verbose, namespace)
 
     def create_class_files(
             self,
@@ -78,7 +78,7 @@ class ClassFilesHelper:
         source_file_path = f'{sources_base_dir}/{source_file_name}'
 
         self.__create_header_file(header_file_path, cwd, is_verbose, namespace)
-        self.__create_source_file(source_file_path, header_file_name, cwd, is_verbose, namespace)
+        self.__create_source_file(source_file_path, cwd, is_verbose, namespace)
 
     def delete_class_files(self, class_name: str, headers_base_dir: str, sources_base_dir: str, is_verbose: bool):
         header_file_name = self.get_header_file_name(class_name)
@@ -144,19 +144,17 @@ class ClassFilesHelper:
     def __create_header_file(self, header_file_path: str, cwd: str, is_verbose: bool, namespace):
         file_content = '#pragma once'
         if namespace is not None:
-            file_content += f'\n\nnamespace {namespace}\n{{\n\n}}\n'
+            file_content += f'\n\nnamespace {namespace}\n{{\n\n}} // namespace {namespace}\n'
 
         self.command_runner.run_command(f'{self.COMMAND_CREATE_FILE} {header_file_path}', cwd, is_verbose)
         header_file = self.file_opener.open(header_file_path)
         header_file.replace_content(file_content)
 
-    def __create_source_file(self, source_file_path: str, header_file_name: str, cwd: str, is_verbose: bool, namespace):
+    def __create_source_file(self, source_file_path: str, cwd: str, is_verbose: bool, namespace):
         file_content = ''
-        if header_file_name:
-            file_content = f'#include "BeastEngine/{header_file_name}"'
 
         if namespace is not None:
-            file_content += f'\n\nnamespace {namespace}\n{{\n\n}}\n'
+            file_content += f'\n\nnamespace {namespace}\n{{\n\n}} // namespace {namespace}\n'
 
         self.command_runner.run_command(f'{self.COMMAND_CREATE_FILE} {source_file_path}', cwd, is_verbose)
         source_file = self.file_opener.open(source_file_path)

--- a/scripts/src/beastengine/commands/class_commands/class_remove.py
+++ b/scripts/src/beastengine/commands/class_commands/class_remove.py
@@ -24,7 +24,7 @@ If class name contains slashes, it will also delete empty subdirectories inside 
         parser = create_arguments_parser(usage=BeastCommandHelper.format_text(self.PROGRAM_USAGE))
         parser.add_argument('class_name', help='class to add', metavar='<class_name>')
 
-        command_line_arguments = parser.parse_args(sys.argv[3:])
+        command_line_arguments = parser.parse_args(sys.argv[4:])
         is_verbose = is_verbose_set(command_line_arguments)
 
         class_name = command_line_arguments.class_name

--- a/scripts/src/config/config_manager.py
+++ b/scripts/src/config/config_manager.py
@@ -58,6 +58,9 @@ class Config:
 class ConfigManager:
     JSON_STR_INDENT = 2
 
+    TARGET_NAME_LIB = 'lib'
+    TARGET_NAME_TESTS = 'tests'
+
     json_config: dict
     config: Config
 
@@ -70,6 +73,15 @@ class ConfigManager:
 
     def update_config(self):
         self.json_manager.save_to_file(self.json_config, self.config_path, self.JSON_STR_INDENT)
+
+    def get_target_config_by_name(self, target_name: str) -> Config.CMake.Target:
+        if target_name == self.TARGET_NAME_LIB:
+            return self.config.cmake.lib
+
+        if target_name == self.TARGET_NAME_TESTS:
+            return self.config.cmake.tests
+
+        return None
 
     def __generate_config_objects(self):
         self.config = Config()

--- a/scripts/src/config/config_names.py
+++ b/scripts/src/config/config_names.py
@@ -22,5 +22,13 @@ class ConfigNames(Enum):
         names += ']'
         return names
 
+    @staticmethod
+    def all_configs():
+        configs = []
+        for name, member in ConfigNames.__members__.items():
+            configs.append(member)
+
+        return configs
+
     def __str__(self):
         return self.value

--- a/scripts/src/functions.py
+++ b/scripts/src/functions.py
@@ -23,7 +23,7 @@ def get_config_path():
 
 
 def is_verbose_set(args):
-    return args.verbose
+    return not args.no_verbose
 
 
 def get_target_cmake_variables_full_file_path(cmake_dir_name: str, variables_config: Config.CMake.Target.Variables):
@@ -36,5 +36,5 @@ def create_arguments_parser(program=None, usage=None, description=None, formatte
     else:
         parser = ArgumentParser(prog=program, usage=usage, description=description, formatter_class=formatter_class)
 
-    parser.add_argument('-v', '--verbose', help='show command output', action='store_true')
+    parser.add_argument('-nv', '--no-verbose', help='do not show command output', action='store_true')
     return parser

--- a/scripts/tests/unit/beastengine/commands/class_commands/test_class_add.py
+++ b/scripts/tests/unit/beastengine/commands/class_commands/test_class_add.py
@@ -12,8 +12,6 @@ from tests.tests_utilities.micro_mock import MicroMock
 
 class CommonTestData:
     def __init__(self):
-        self.argv = ['arg1', 'arg2', 'arg3', 'arg4']
-
         self.class_files_helper_mock = MagicMock(class_files_helper.ClassFilesHelper)
 
         self.parser_mock = MagicMock(argparse.ArgumentParser)
@@ -51,13 +49,13 @@ class CommonTestData:
         return MicroMock(class_name=class_name, namespace=namespace, header_only=header_only, source_only=source_only)
 
 
-def test_constructor_will_retrieve_all_arguments_starting_from_fourth():
+def test_constructor_will_retrieve_all_arguments_starting_from_fifth():
     test_data = CommonTestData()
     test_data.mock_create_arguments_parser_function()
     test_data.class_files_helper_mock.class_files_exist = MagicMock(return_value=False)
 
-    sys.argv = ['arg1', 'arg2', 'arg3', 'arg4']
-    expected_arguments = ['arg4']
+    sys.argv = ['arg1', 'arg2', 'arg3', 'arg4', 'arg5', 'arg6']
+    expected_arguments = ['arg5', 'arg6']
 
     class_add.ClassAdd(
         test_data.headers_base_dir,
@@ -87,9 +85,9 @@ def test_constructor_will_add_required_class_name_argument_to_parser():
         test_data.config.cmake.lib,
         test_data.config_manager_mock
     )
-    test_data\
-        .parser_mock\
-        .add_argument\
+    test_data \
+        .parser_mock \
+        .add_argument \
         .assert_has_calls(
             [call(expected_argument_name, help=expected_argument_help, metavar=expected_argument_metavar)],
             any_order=True
@@ -119,7 +117,8 @@ def test_constructor_will_add_namespace_optional_argument_to_parser():
         .parser_mock \
         .add_argument \
         .assert_has_calls(
-            [call(expected_argument_name_short, expected_argument_full_name, help=expected_argument_help, type=expected_argument_type)],
+            [call(expected_argument_name_short, expected_argument_full_name, help=expected_argument_help,
+                  type=expected_argument_type)],
             any_order=True
         )
 
@@ -213,9 +212,9 @@ def test_constructor_will_create_class_if_passed_class_does_not_exist():
         test_data.config_manager_mock
     )
 
-    test_data\
-        .class_files_helper_mock\
-        .create_class_files\
+    test_data \
+        .class_files_helper_mock \
+        .create_class_files \
         .assert_called_with(
             expected_class_name,
             test_data.headers_base_dir,
@@ -249,9 +248,9 @@ def test_constructor_will_create_class_with_namespace_parameter_if_one_specified
         test_data.config_manager_mock
     )
 
-    test_data\
-        .class_files_helper_mock\
-        .create_class_files\
+    test_data \
+        .class_files_helper_mock \
+        .create_class_files \
         .assert_called_with(
             class_name,
             test_data.headers_base_dir,

--- a/scripts/tests/unit/beastengine/commands/class_commands/test_class_command.py
+++ b/scripts/tests/unit/beastengine/commands/class_commands/test_class_command.py
@@ -14,8 +14,6 @@ from tests.tests_utilities.micro_mock import MicroMock
 
 class CommonTestData:
     def __init__(self):
-        self.argv = ['arg1', 'arg2', 'arg3', 'arg4']
-
         self.parser_mock = MagicMock(argparse.ArgumentParser)
         self.parser_mock.parse_args = MagicMock()
         self.project_dir = 'project/dir'

--- a/scripts/tests/unit/beastengine/commands/class_commands/test_class_command.py
+++ b/scripts/tests/unit/beastengine/commands/class_commands/test_class_command.py
@@ -3,7 +3,7 @@ import builtins
 import sys
 import pytest
 
-from mock import MagicMock
+from mock import MagicMock, call
 
 from src.beastengine.beast_command_helper import BeastCommandHelper
 from src.beastengine.commands.class_commands.class_files_helper import ClassFilesHelper
@@ -47,12 +47,12 @@ class CommonTestData:
         builtins.print = self.print_mock
 
 
-def test_constructor_will_retrieve_only_third_argument():
+def test_constructor_will_retrieve_only_third_and_fourth_arguments():
     test_data = CommonTestData()
     test_data.mock_create_arguments_parser_function()
 
-    sys.argv = ['arg1', 'arg2', 'arg3', 'arg4']
-    expected_arguments = ['arg3']
+    sys.argv = ['arg1', 'arg2', 'arg3', 'arg4', 'arg5']
+    expected_arguments = ['arg3', 'arg4']
 
     class_command.ClassCommand(
         test_data.config_manager_mock,
@@ -64,7 +64,7 @@ def test_constructor_will_retrieve_only_third_argument():
     test_data.parser_mock.parse_args.assert_called_with(expected_arguments)
 
 
-def test_constructor_will_add_required_argument_to_parser():
+def test_constructor_will_add_required_command_argument_to_parser():
     expected_argument_name = 'command'
     expected_argument_help = 'command to execute'
     expected_argument_metavar = '<command>'
@@ -83,7 +83,36 @@ def test_constructor_will_add_required_argument_to_parser():
     test_data\
         .parser_mock\
         .add_argument\
-        .assert_called_with(expected_argument_name, help=expected_argument_help, metavar=expected_argument_metavar)
+        .assert_has_calls(
+            [call(expected_argument_name, help=expected_argument_help, metavar=expected_argument_metavar)],
+            any_order=True
+        )
+
+
+def test_constructor_will_add_required_target_argument_to_parser():
+    expected_argument_name = 'target'
+    expected_argument_help = 'target for which the files should be added'
+    expected_argument_metavar = '<target>'
+
+    test_data = CommonTestData()
+    test_data.mock_create_arguments_parser_function()
+    test_data.parser_mock.add_argument = MagicMock()
+
+    test_data.class_files_helper_mock.class_files_exist = MagicMock(return_value=False)
+
+    class_command.ClassCommand(
+        test_data.config_manager_mock,
+        test_data.cmake_mock,
+        test_data.target_config_manager_mock,
+        test_data.class_files_helper_mock
+    )
+    test_data \
+        .parser_mock \
+        .add_argument \
+        .assert_has_calls(
+            [call(expected_argument_name, help=expected_argument_help, metavar=expected_argument_metavar)],
+            any_order=True
+        )
 
 
 def test_constructor_will_retrieve_headers_base_directory():
@@ -91,6 +120,7 @@ def test_constructor_will_retrieve_headers_base_directory():
 
     test_data = CommonTestData()
     test_data.mock_create_arguments_parser_function()
+    test_data.config_manager_mock.get_target_config_by_name = MagicMock(return_value=test_data.config.cmake.lib)
     test_data.target_config_manager_mock.get_headers_base_directory = MagicMock(return_value=expected_headers_base_directory)
 
     class_command.ClassCommand(
@@ -111,6 +141,7 @@ def test_constructor_will_retrieve_sources_base_directory():
 
     test_data = CommonTestData()
     test_data.mock_create_arguments_parser_function()
+    test_data.config_manager_mock.get_target_config_by_name = MagicMock(return_value=test_data.config.cmake.lib)
     test_data.target_config_manager_mock.get_sources_base_directory = MagicMock(return_value=expected_sources_base_directory)
 
     class_command.ClassCommand(
@@ -135,8 +166,9 @@ def test_constructor_will_call_add_class_command_when_valid_command_line_argumen
     test_data = CommonTestData()
     test_data.mock_create_arguments_parser_function()
 
-    cli_arguments_mock = MicroMock(command=expected_command)
+    cli_arguments_mock = MicroMock(command=expected_command, target=ConfigManager.TARGET_NAME_LIB)
     test_data.parser_mock.parse_args = MagicMock(return_value=cli_arguments_mock)
+    test_data.config_manager_mock.get_target_config_by_name = MagicMock(return_value=test_data.config.cmake.lib)
     test_data.target_config_manager_mock.get_headers_base_directory = MagicMock(return_value=headers_base_directory)
     test_data.target_config_manager_mock.get_sources_base_directory = MagicMock(return_value=sources_base_directory)
 
@@ -172,8 +204,9 @@ def test_constructor_will_call_remove_class_command_when_valid_command_line_argu
     test_data = CommonTestData()
     test_data.mock_create_arguments_parser_function()
 
-    cli_arguments_mock = MicroMock(command=expected_command)
+    cli_arguments_mock = MicroMock(command=expected_command, target=ConfigManager.TARGET_NAME_LIB)
     test_data.parser_mock.parse_args = MagicMock(return_value=cli_arguments_mock)
+    test_data.config_manager_mock.get_target_config_by_name = MagicMock(return_value=test_data.config.cmake.lib)
     test_data.target_config_manager_mock.get_headers_base_directory = MagicMock(return_value=headers_base_directory)
     test_data.target_config_manager_mock.get_sources_base_directory = MagicMock(return_value=sources_base_directory)
 
@@ -209,8 +242,9 @@ def test_constructor_will_show_headers_and_sources_base_directories_when_valid_c
     test_data.mock_create_arguments_parser_function()
     test_data.mock_print_function()
 
-    cli_arguments_mock = MicroMock(command=expected_command)
+    cli_arguments_mock = MicroMock(command=expected_command, target=ConfigManager.TARGET_NAME_LIB)
     test_data.parser_mock.parse_args = MagicMock(return_value=cli_arguments_mock)
+    test_data.config_manager_mock.get_target_config_by_name = MagicMock(return_value=test_data.config.cmake.lib)
     test_data.target_config_manager_mock.get_headers_base_directory = MagicMock(return_value=headers_base_directory)
     test_data.target_config_manager_mock.get_sources_base_directory = MagicMock(return_value=sources_base_directory)
 
@@ -233,3 +267,24 @@ def test_constructor_will_show_headers_and_sources_base_directories_when_valid_c
         f'Headers base directory: {headers_base_directory}\nSources base directory: {sources_base_directory}'
     )
 
+
+def test_constructor_will_print_error_message_when_invalid_target_defined():
+    invalid_target_name = 'invalid'
+    expected_error_message = f'\'{invalid_target_name}\' is not a valid target!'
+
+    test_data = CommonTestData()
+    test_data.mock_create_arguments_parser_function()
+    cli_arguments_mock = MicroMock(command='command', target=invalid_target_name)
+    test_data.parser_mock.parse_args = MagicMock(return_value=cli_arguments_mock)
+    test_data.config_manager_mock.get_target_config_by_name = MagicMock(return_value=None)
+
+    test_data.mock_print_function()
+
+    class_command.ClassCommand(
+        test_data.config_manager_mock,
+        test_data.cmake_mock,
+        test_data.target_config_manager_mock,
+        test_data.class_files_helper_mock
+    )
+
+    test_data.print_mock.assert_called_with(expected_error_message)

--- a/scripts/tests/unit/beastengine/commands/class_commands/test_class_files_helper.py
+++ b/scripts/tests/unit/beastengine/commands/class_commands/test_class_files_helper.py
@@ -191,7 +191,7 @@ def test_create_class_files_will_create_class_files_with_proper_content():
     is_verbose = True
 
     expected_header_file_content = '#pragma once'
-    expected_source_file_content = f'#include "BeastEngine/{class_name}.h"'
+    expected_source_file_content = f''
 
     cwd = '/project/dir'
     class_files_helper.get_project_path = MagicMock(return_value=cwd)
@@ -224,15 +224,15 @@ f'''#pragma once
 namespace {expected_namespace}
 {{
 
-}}
+}} // namespace {expected_namespace}
 '''
     expected_source_file_content =\
-f'''#include "BeastEngine/{class_name}.h"
+f'''
 
 namespace {expected_namespace}
 {{
 
-}}
+}} // namespace {expected_namespace}
 '''
 
     cwd = '/project/dir'

--- a/scripts/tests/unit/beastengine/commands/class_commands/test_class_remove.py
+++ b/scripts/tests/unit/beastengine/commands/class_commands/test_class_remove.py
@@ -12,8 +12,6 @@ from tests.tests_utilities.micro_mock import MicroMock
 
 class CommonTestData:
     def __init__(self):
-        self.argv = ['arg1', 'arg2', 'arg3', 'arg4']
-
         self.class_files_helper_mock = MagicMock(class_files_helper.ClassFilesHelper)
 
         self.parser_mock = MagicMock(argparse.ArgumentParser)
@@ -44,13 +42,13 @@ class CommonTestData:
         pass
 
 
-def test_constructor_will_retrieve_all_arguments_starting_from_fourth():
+def test_constructor_will_retrieve_all_arguments_starting_from_fifth():
     test_data = CommonTestData()
     test_data.mock_create_arguments_parser_function()
     test_data.class_files_helper_mock.class_files_exist = MagicMock(return_value=False)
 
-    sys.argv = ['arg1', 'arg2', 'arg3', 'arg4']
-    expected_arguments = ['arg4']
+    sys.argv = ['arg1', 'arg2', 'arg3', 'arg4', 'arg5', 'arg6']
+    expected_arguments = ['arg5', 'arg6']
 
     class_remove.ClassRemove(
         test_data.headers_base_dir,

--- a/scripts/tests/unit/beastengine/commands/test_build.py
+++ b/scripts/tests/unit/beastengine/commands/test_build.py
@@ -21,8 +21,6 @@ class CommonTestData:
     ]
 
     def __init__(self):
-        self.argv = ['arg1', 'arg2', 'arg3', 'arg4']
-
         self.parser_mock = MagicMock(argparse.ArgumentParser)
         self.parser_mock.parse_args = MagicMock()
         self.project_dir = 'project/dir'

--- a/scripts/tests/unit/beastengine/commands/test_build.py
+++ b/scripts/tests/unit/beastengine/commands/test_build.py
@@ -99,15 +99,13 @@ def test_constructor_will_save_verbose_argument_into_variable(expected_verbose):
 @pytest.mark.parametrize('config', ['', False, None])
 def test_execute_will_print_warning_message_when_passed_arguments_config_parameter_is_empty(config):
     expected_arguments = MicroMock(config=config)
-    expected_default_config = build.ConfigNames.CONFIG_DEBUG
     expected_info_message =\
         f'{colorama.Fore.YELLOW}' \
         f'No configuration specified, ' \
-        f'building for default \'{expected_default_config}\' configuration {colorama.Fore.RESET}'
+        f'building for all configurations {colorama.Fore.RESET}'
 
     test_data = CommonTestData()
     test_data.mock_print_function()
-    test_data.config.default_build_type = expected_default_config
     test_data.mock_config_names_from_string_method()
 
     test_data.parser_mock.parse_args = MagicMock(return_value=expected_arguments)
@@ -117,26 +115,6 @@ def test_execute_will_print_warning_message_when_passed_arguments_config_paramet
     sut.execute()
 
     test_data.print_mock.assert_called_with(expected_info_message)
-
-
-@pytest.mark.parametrize('config', ['', False, None])
-def test_execute_will_convert_default_config_string_to_enum_when_passed_config_argument_is_empty(config):
-    expected_default_config = build.ConfigNames.CONFIG_DEBUG
-    expected_arguments = MicroMock(config=config)
-
-    test_data = CommonTestData()
-    test_data.mock_print_function()
-    test_data.config.default_build_type = expected_default_config
-    test_data.mock_config_names_from_string_method()
-
-    test_data.parser_mock.parse_args = MagicMock(return_value=expected_arguments)
-    test_data.mock_create_arguments_parser_function()
-
-    sut = build.Build(test_data.config_manager_mock, MagicMock(CMake))
-    sut.execute()
-
-    build.ConfigNames.from_string.assert_called_once_with(expected_default_config)
-
 
 @pytest.mark.parametrize(
     'expected_config', CommonTestData.CONFIG_NAMES

--- a/scripts/tests/unit/beastengine/commands/test_configure.py
+++ b/scripts/tests/unit/beastengine/commands/test_configure.py
@@ -10,8 +10,6 @@ from src.beastengine.commands import configure
 
 class CommonTestData:
     def __init__(self):
-        self.argv = ['arg1', 'arg2', 'arg3', 'arg4']
-
         self.parser_mock = MagicMock(argparse.ArgumentParser)
         self.parser_mock.parse_args = MagicMock()
         self.project_dir = 'project/dir'

--- a/scripts/tests/unit/beastengine/commands/test_init.py
+++ b/scripts/tests/unit/beastengine/commands/test_init.py
@@ -14,8 +14,6 @@ from src.commandrunners.command_runner import CommandRunner
 
 class CommonTestData:
     def __init__(self):
-        self.argv = ['arg1', 'arg2', 'arg3', 'arg4']
-
         self.parser_mock = MagicMock(argparse.ArgumentParser)
         self.parser_mock.parse_args = MagicMock()
         self.project_dir = 'project/dir'

--- a/scripts/tests/unit/config/test_config_manager.py
+++ b/scripts/tests/unit/config/test_config_manager.py
@@ -2,6 +2,8 @@ import copy
 import json
 from unittest.mock import MagicMock
 
+import pytest
+
 from src.config.config_manager import ConfigManager, Config
 from src.json_utils.json_manager import JSONManager
 
@@ -433,3 +435,32 @@ def test_update_config_will_save_updated_config_object_into_selected_config_file
     test_data.json_manager_mock.save_to_file.assert_called_with(sut.json_config, file_path, sut.JSON_STR_INDENT)
     assert config_before != sut.config
     assert sut.config == expected_config_after
+
+
+def test_get_target_config_bu_name_will_return_empty_object_if_invalid_name_passed():
+    invalid_target_name = 'Invalid'
+
+    test_data = CommonTestData()
+    expected_config = None
+
+    file_path = 'path/to/json/file/json'
+    test_data.json_manager_mock.load_from_file.return_value = test_data.config_json
+
+    sut = ConfigManager(file_path, test_data.json_manager_mock)
+    actual_config = sut.get_target_config_by_name(invalid_target_name)
+
+    assert expected_config == actual_config
+
+
+@pytest.mark.parametrize('expected_target_name', [ConfigManager.TARGET_NAME_LIB, ConfigManager.TARGET_NAME_TESTS])
+def test_get_target_config_by_name_will_return_valid_config_if_valid_name_passed(expected_target_name):
+    test_data = CommonTestData()
+    expected_config = test_data.config_json['cmake_config']['targets'][expected_target_name]
+
+    file_path = 'path/to/json/file/json'
+    test_data.json_manager_mock.load_from_file.return_value = test_data.config_json
+
+    sut = ConfigManager(file_path, test_data.json_manager_mock)
+    actual_config = sut.get_target_config_by_name(expected_target_name)
+
+    assert expected_config['target_name'] == actual_config.target_name

--- a/scripts/tests/unit/config/test_config_names.py
+++ b/scripts/tests/unit/config/test_config_names.py
@@ -1,0 +1,25 @@
+from unittest.mock import MagicMock
+
+from src.config.config_manager import ConfigManager, Config
+from src.config.config_names import ConfigNames
+
+
+def test_available_names_will_return_valid_config_names():
+    expected_configurations =\
+        f'[{ConfigNames.CONFIG_DEBUG}, ' \
+        f'{ConfigNames.CONFIG_RELEASE}, {ConfigNames.CONFIG_REL_WITH_DEBUG}, {ConfigNames.CONFIG_MIN_SIZE_REL}]'
+
+    actual_configurations = ConfigNames.available_names()
+    assert expected_configurations == actual_configurations
+
+
+def test_all_configs_will_return_array_of_configurations():
+    expected_configurations = [
+        ConfigNames(ConfigNames.CONFIG_DEBUG),
+        ConfigNames(ConfigNames.CONFIG_RELEASE),
+        ConfigNames(ConfigNames.CONFIG_REL_WITH_DEBUG),
+        ConfigNames(ConfigNames.CONFIG_MIN_SIZE_REL),
+    ]
+    actual_configurations = ConfigNames.all_configs()
+
+    assert expected_configurations == actual_configurations

--- a/scripts/tests/unit/test_functions.py
+++ b/scripts/tests/unit/test_functions.py
@@ -42,15 +42,15 @@ def test_get_config_path_will_return_valid_path():
     assert functions.get_config_path() == expected_config_path
 
 
-def test_is_verbose_set_will_return_false_when_verbose_attribute_is_set_to_false():
-    data = MicroMock(verbose=False)
+def test_is_verbose_set_will_return_false_when_no_verbose_attribute_is_set_to_true():
+    data = MicroMock(no_verbose=True)
 
     expected_result = False
     assert functions.is_verbose_set(data) == expected_result
 
 
-def test_is_verbose_set_will_return_false_when_verbose_attribute_is_set_to_true():
-    data = MicroMock(verbose=True)
+def test_is_verbose_set_will_return_true_when_no_verbose_attribute_is_set_to_false():
+    data = MicroMock(no_verbose=False)
 
     expected_result = True
     assert functions.is_verbose_set(data) == expected_result
@@ -130,9 +130,9 @@ def test_create_arguments_parser_will_create_parser_with_given_formatter_class()
 
 
 def test_create_arguments_parser_will_create_parser_with_verbose_as_optional_argument():
-    expected_argument_short_name = '-v'
-    expected_argument_full_name = '--verbose'
-    expected_argument_help = 'show command output'
+    expected_argument_short_name = '-nv'
+    expected_argument_full_name = '--no-verbose'
+    expected_argument_help = 'do not show command output'
     expected_argument_action = 'store_true'
 
     add_argument_mock = MagicMock()


### PR DESCRIPTION
 - Changed `build` command so that if no configuration is specified, the build is performed for all available configurations
 - Modified `class` commands to accept `target` parameter. From now, files can be added and removed from both `BeastEngine` and `Lab` targets
 - `class add` and `class remove` regenerates now the `CMake` project to include the added/removed files
 - Added new `install` command which allows user to install/update `Conan` dependencies without a need to init the project again.