### PR TITLE
15 - windows window refactor

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -14,7 +14,7 @@ AllowShortCaseLabelsOnASingleLine: true
 AllowShortFunctionsOnASingleLine: Empty
 AllowShortIfStatementsOnASingleLine: Never
 AllowShortLoopsOnASingleLine: false
-AllowShortLambdasOnASingleLine: Empty
+AllowShortLambdasOnASingleLine: All
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: true
 AlwaysBreakTemplateDeclarations: false

--- a/apps/sandbox.cpp
+++ b/apps/sandbox.cpp
@@ -17,7 +17,6 @@ public:
     {
         m_engine->PrintInfo();
 
-
         while (m_isRunning)
         {
             const auto& coords = m_mouse->GetCoordinates();

--- a/tests/Unit/Core/BeastEngineTest.h
+++ b/tests/Unit/Core/BeastEngineTest.h
@@ -15,7 +15,7 @@ namespace be::tests::unit
     class WindowFactoryMock : public IWindowFactory
     {
     public:
-        virtual UniquePtr<IWindow> Create(const WindowDescriptor& descriptor) override
+        UniquePtr<IWindow> Create(const WindowDescriptor& descriptor) override
         {
             return UniquePtr<IWindow>(CreateProxy());
         }


### PR DESCRIPTION
 - Split messages handling code into smaller methods
 - `WinAPI` events are now directly mapped to responsible functions to avoid huge switch statement.