### PR TITLE
Renderer Clean Up

### DIFF
--- a/src/Beast/BeastEngine.h
+++ b/src/Beast/BeastEngine.h
@@ -8,7 +8,7 @@
 #include "Beast/Common/Helpers.h"
 #include "Beast/Common/Types.h"
 
-#include "Beast/Graphics/Graphics.h"
+#include "Beast/Graphics/IGraphics.h"
 
 namespace be
 {

--- a/src/Beast/CMakeLists.txt
+++ b/src/Beast/CMakeLists.txt
@@ -50,7 +50,7 @@ add_library(
             
             
             
-            "Graphics/D3D11/Debug.h" "Graphics/D3D11/Buffer.h" "Graphics/D3D11/D3D11.h"  "Graphics/Graphics.h"     "Graphics/GraphicsFactory.h" "Graphics/GraphicsFactory.cpp" "Ecs/Components/Core.h" "Graphics/2DRenderer.h" "Graphics/2DRenderer.cpp" "Graphics/D3D11/Shader.h" "Graphics/Types.h" "Ecs/Components/Graphics.h"  "Logging.h" "Ecs.h" "Graphics/D3D11/Graphics.h" "Graphics/D3D11/Graphics.cpp"  "Graphics/D3D11/Utils.h" "Graphics/D3D11/Utils.cpp" "Graphics/D3D11/RenderTarget.h")
+            "Graphics/D3D11/Debug.h" "Graphics/D3D11/Buffer.h" "Graphics/D3D11/D3D11.h"  "Graphics/IGraphics.h"     "Graphics/GraphicsFactory.h" "Graphics/GraphicsFactory.cpp" "Ecs/Components/Core.h" "Graphics/2DRenderer.h" "Graphics/2DRenderer.cpp" "Graphics/D3D11/Shader.h" "Graphics/Types.h" "Ecs/Components/Graphics.h"  "Logging.h" "Ecs.h" "Graphics/D3D11/Graphics.h" "Graphics/D3D11/Graphics.cpp"  "Graphics/D3D11/Utils.h" "Graphics/D3D11/Utils.cpp" "Graphics/D3D11/RenderTarget.h")
 target_include_directories(
     BeastCore
         PUBLIC

--- a/src/Beast/Graphics/2DRenderer.cpp
+++ b/src/Beast/Graphics/2DRenderer.cpp
@@ -4,10 +4,12 @@
 
 namespace be::graphics
 {
-    Renderer2D::Renderer2D(be::Unique<IGraphics> graphics)
+    Renderer2D::Renderer2D(be::Unique<IGraphics> graphics, uint32 maxNumberOfSprites)
         : m_graphics(std::move(graphics))
     {
-        m_buffer = m_graphics->CreateVertexBuffer(VERTEX_STRIDE, sizeof(Vertex) * 3 * 1000);
+        const uint32 vertexCount = sizeof(Vertex) * 3 * maxNumberOfSprites;
+        m_buffer = m_graphics->CreateVertexBuffer(VERTEX_STRIDE, vertexCount);
+
         be::graphics::InputLayout layout{
             .vertexAttributes = {
                 {"POSITION", be::graphics::InputLayout::VertexAttribute::Format::Vec2},
@@ -39,9 +41,9 @@ namespace be::graphics
         m_framePrimitives.emplace_back(std::move(primitive));
     }
 
-    void Renderer2D::EndFrame()
+    void Renderer2D::EndFrame(const Viewport& viewport)
     {
-        BE_ASSERT_MSG(m_hasFrameStarted, "Frame must be started before it can be ended!");
+        BE_ASSERT_MSG(m_hasFrameStarted, "Frame must be started first, before it can be ended!");
         {
             const uint32 verticesCount = static_cast<uint32>(m_framePrimitives.size() * 3u);
 
@@ -69,7 +71,7 @@ namespace be::graphics
             pipeline.vertexBuffer = m_buffer;
             pipeline.vertexShaderStage.shader = m_vertexShader;
             pipeline.pixelShaderStage.shader = m_pixelShader;
-            pipeline.viewport.dimensions = {800.0f, 600.0f};
+            pipeline.viewport = viewport;
             pipeline.drawCall.vertexCount = verticesCount;
 
             m_graphics->Clear({0.6f, 0.2f, 0.3f, 1.0f});

--- a/src/Beast/Graphics/2DRenderer.h
+++ b/src/Beast/Graphics/2DRenderer.h
@@ -2,7 +2,7 @@
 #include "Beast/Ecs/Components/Core.h"
 #include "Beast/Ecs/Components/Graphics.h"
 
-#include "Beast/Graphics/Graphics.h"
+#include "Beast/Graphics/IGraphics.h"
 #include "Beast/Graphics/Types.h"
 
 #include "Beast/Debug.h"
@@ -19,11 +19,11 @@ namespace be::graphics
         };
 
     public:
-        explicit Renderer2D(be::Unique<IGraphics> graphics);
+        explicit Renderer2D(be::Unique<IGraphics> graphics, uint32 maxNumberOfSprites);
 
         void StartFrame();
         void AddSprite(const Transform& transform, const Sprite& sprite);
-        void EndFrame();
+        void EndFrame(const Viewport& viewport);
 
     private:
         be::Unique<IGraphics> m_graphics;

--- a/src/Beast/Graphics/D3D11/Graphics.h
+++ b/src/Beast/Graphics/D3D11/Graphics.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "Beast/Graphics/Graphics.h"
+#include "Beast/Graphics/IGraphics.h"
 #include "Beast/Graphics/D3D11/D3D11.h"
 #include "Beast/Graphics/D3D11/Buffer.h"
 #include "Beast/Graphics/D3D11/Shader.h"

--- a/src/Beast/Graphics/GraphicsFactory.h
+++ b/src/Beast/Graphics/GraphicsFactory.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "Beast/Graphics/Graphics.h"
+#include "Beast/Graphics/IGraphics.h"
 
 #include "Beast/Windows/IWindow.h"
 #include "Beast/Common/Helpers.h"

--- a/src/Beast/Graphics/IGraphics.h
+++ b/src/Beast/Graphics/IGraphics.h
@@ -12,6 +12,11 @@ namespace be
 
 namespace be::graphics
 {
+    struct Viewport
+    {
+        Vec2 dimensions;
+    };
+
     struct Pipeline
     {
         struct VSStage
@@ -22,11 +27,6 @@ namespace be::graphics
         struct PSStage
         {
             PixelShader shader;
-        };
-
-        struct Viewport
-        {
-            Vec2 dimensions;
         };
 
         struct DrawCall


### PR DESCRIPTION
Added required Renderer features. Renamed Graphics/Graphics.h to Graphics/IGraphics.h.

Decided not to add `VertexLayout` to the Renderer2D's constructor as it's related to shader and will most likely be reworked in the future anyway. The current implementation is good enough.